### PR TITLE
Force compilation of the dll when DOKAN_DLL_OUTPUT_PATH is set

### DIFF
--- a/dokan-sys/build.rs
+++ b/dokan-sys/build.rs
@@ -73,7 +73,7 @@ fn check_dokan_env(version_major: &str) -> bool {
 	}
 }
 
-fn build_dokan(compiler: &Tool, version_major: &str) {
+fn build_dokan(compiler: &Tool, version_major: &str, output_path: Option<String>) {
 	let out_dir = env::var("OUT_DIR").unwrap();
 	let src = fs::read_dir("src/dokany/dokan")
 		.unwrap()
@@ -121,7 +121,7 @@ fn build_dokan(compiler: &Tool, version_major: &str) {
 			))
 	};
 	assert!(compiler_cmd.output().unwrap().status.success());
-	if let Ok(output_path) = env::var("DOKAN_DLL_OUTPUT_PATH") {
+	if let Some(output_path) = &output_path {
 		fs::copy(dll_path, format!("{}/{}", output_path, dll_name)).unwrap();
 	}
 	println!("cargo:rerun-if-env-changed=DOKAN_DLL_OUTPUT_PATH");
@@ -144,7 +144,8 @@ fn main() {
 	);
 	let version_major = &version[..1];
 	println!("cargo:rustc-link-lib=dylib=dokan{}", version_major);
-	if !check_dokan_env(version_major) {
-		build_dokan(&compiler, version_major);
+	let output_path = env::var("DOKAN_DLL_OUTPUT_PATH").ok();
+	if !check_dokan_env(version_major) || output_path.is_some() {
+		build_dokan(&compiler, version_major, output_path);
 	};
 }


### PR DESCRIPTION
The build.rs script would compile the dokan2.dll only if dokan is not installed. It is sometimes desirable to compile nevertheless and use the compiled dll instead of the one in C:\Windows\System32.

There was already DOKAN_DLL_OUTPUT_PATH to instruct where to copy the dll, but it would not be used when dokan is installed on the system. This change "forces" compilation of the dll when the environment variable is set.