### PR TITLE
Add ARM64 (aarch64) target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Generally, it is recommended to use the `dokan` crate, which has the unsafe raw 
 
 `dokan-sys`, which is also a dependency of `dokan`, requires the import library of the native Dokan library in order to link against it.
 
-If the `DokanLibrary2_LibraryPath_{ARCH}` environment variable exists (`{ARCH}` can be `x86` or `x64` depending on the architecture of your target platform), `dokan-sys` will look for the import library in the directory specified by the aforementioned environment variable. These environment variables are automatically set by Dokan's installer since v1.0.0.
+If the `DokanLibrary2_LibraryPath_{ARCH}` environment variable exists (`{ARCH}` can be `x86`, `x64`, or `ARM64` depending on the architecture of your target platform), `dokan-sys` will look for the import library in the directory specified by the aforementioned environment variable. These environment variables are automatically set by Dokan's installer since v1.0.0.
 
 Otherwise, `dokan-sys` will build the import library from bundled Dokan source code. The DLL file will be built as well and you can use the `DOKAN_DLL_OUTPUT_PATH` environment variable to have the build script copy it to the specified directory.
 

--- a/dokan-sys/build.rs
+++ b/dokan-sys/build.rs
@@ -57,7 +57,8 @@ fn check_dokan_env(version_major: &str) -> bool {
 	let arch = match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_ref() {
 		"x86" => "x86",
 		"x86_64" => "x64",
-		_ => panic!("Unsupported target architecture!"),
+		"aarch64" => "ARM64",
+		other => panic!("Unsupported target architecture: {}", other),
 	};
 	let env_name = format!("DokanLibrary{}_LibraryPath_{}", version_major, arch);
 	println!("cargo:rerun-if-env-changed={}", env_name);


### PR DESCRIPTION
First off — thank you for maintaining these Rust bindings to Dokany. We've been running `dokan-rust` in production on Windows ARM64 machines for about six months, carrying a small local patch to make it build there, and we'd like to upstream that change so it's maintained here rather than living in our fork.


`dokan-sys` panics at build time on any target architecture other than `x86`/`x86_64`. So cargo build --target aarch64-pc-windows-msvc fails today, even though Dokany ships ARM64 binaries and the v2.3.0 installer provides an ARM64 import library. This PR adds the aarch64 → ARM64 mapping in check_dokan_env, so dokan-sys/dokan build for Windows on ARM64.

Validated on a native Windows-on-ARM64 machine with Dokany v2.3.0 installed:

- cargo build --release --workspace --all-targets succeeds. Before this change the same command panics with Unsupported target architecture!.
- The Dokan kernel driver mounts and responds correctly on ARM64 (the usage_tests exercise it against a real volume).